### PR TITLE
Fix severity column handling

### DIFF
--- a/scan_titles_weighted.py
+++ b/scan_titles_weighted.py
@@ -3,7 +3,21 @@ import pandas as pd
 import re
 
 def scan_titles_weighted(titles, df_mapping, df_severity):
-    severity_lookup = dict(zip(df_severity['Keyword'].str.lower(), df_severity['SeverityScoreDeduction']))
+    # Normalize column names to avoid attribute errors when using `.str`
+    df_severity = df_severity.rename(columns=lambda c: c.strip().lower())
+
+    if 'severityscorededuction' in df_severity.columns:
+        df_severity.rename(columns={'severityscorededuction': 'severity'}, inplace=True)
+
+    if 'keyword' not in df_severity.columns or 'severity' not in df_severity.columns:
+        raise ValueError("df_severity must contain 'keyword' and 'severity' columns")
+
+    severity_lookup = dict(
+        zip(
+            df_severity['keyword'].astype(str).str.lower(),
+            df_severity['severity']
+        )
+    )
     results = []
 
     for title in titles:

--- a/scan_titles_weighted_contextual_v3_riskaware.py
+++ b/scan_titles_weighted_contextual_v3_riskaware.py
@@ -5,6 +5,17 @@ from context_flags import detect_contextual_flags
 
 def scan_titles_weighted(titles, df_keywords, df_severity):
     print("DEBUG: Columns in df_severity =", df_severity.columns.tolist())
+
+    # Standardise df_severity column names so `.str` can be safely used
+    df_severity = df_severity.rename(columns=lambda c: c.strip().lower())
+    if 'severityscorededuction' in df_severity.columns:
+        df_severity.rename(columns={'severityscorededuction': 'severity'}, inplace=True)
+
+    if 'keyword' not in df_severity.columns or 'severity' not in df_severity.columns:
+        raise ValueError("df_severity must contain 'keyword' and 'severity' columns")
+
+    df_severity['keyword'] = df_severity['keyword'].astype(str).str.lower()
+
     results = []
 
     # Risky phrase categories and severity impact


### PR DESCRIPTION
## Summary
- normalize df_severity column names in helper scripts
- avoid attribute errors with `.str`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
import pandas as pd
from scan_titles_weighted import scan_titles_weighted
from scan_titles_weighted_contextual_v3_riskaware import scan_titles_weighted as scan_c

# create test data

titles=['This is fuck', 'limited time', 'nice']

df_keywords=pd.read_csv('updated_keywords_expanded.csv')
df_severity=pd.read_csv('safety_severity_scores.csv')
print('basic', scan_titles_weighted(titles, df_keywords, df_severity).head())

df_severity2=pd.read_csv('safety_severity_scores.csv')
print('context', scan_c(titles, df_keywords, df_severity2).head())
PY

------
https://chatgpt.com/codex/tasks/task_e_6862c51d5e5c83318b671b56786eece3