### PR TITLE
Add missing keyword severity scores

### DIFF
--- a/safety_severity_scores.csv
+++ b/safety_severity_scores.csv
@@ -66,3 +66,16 @@ assault,35
 shocking,10
 you won't believe,15
 gone wrong,10
+abusive,30
+bullied,25
+bullies,25
+bully,25
+crybaby,15
+failure,15
+hate,30
+kills,30
+panic,25
+scams,30
+shamed,20
+toxic,20
+trauma,25


### PR DESCRIPTION
## Summary
- add severity scores for flagged keywords that were missing them

## Testing
- `python3 - <<'PY' ...` (check that no keywords are missing severity scores)


------
https://chatgpt.com/codex/tasks/task_e_6862db5a72e48331b5f26ac2688734f3