### PR TITLE
Fix gradient error and lighten text

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,11 +20,11 @@ st.markdown(
     <style>
         .stApp {
             background-color: #0e1117;
-            color: #e0e0e0;
+            color: #f5f5f5;
         }
         .stDataFrame, .stTable {
             background-color: #0e1117;
-            color: #e0e0e0;
+            color: #f5f5f5;
         }
     </style>
     """,

--- a/app_contextual.py
+++ b/app_contextual.py
@@ -18,11 +18,11 @@ st.markdown(
     <style>
         .stApp {
             background-color: #0e1117;
-            color: #e0e0e0;
+            color: #f5f5f5;
         }
         .stDataFrame, .stTable {
             background-color: #0e1117;
-            color: #e0e0e0;
+            color: #f5f5f5;
         }
     </style>
     """,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas
 requests
 openpyxl
 python-dotenv
+matplotlib


### PR DESCRIPTION
## Summary
- lighten default text color for better visibility
- add matplotlib dependency for pandas background gradients

## Testing
- `python -m py_compile app.py app_contextual.py context_flags.py scan_titles_weighted.py scan_titles_weighted_contextual_v3_riskaware.py`

------
https://chatgpt.com/codex/tasks/task_e_6862ddffbe4483318ee2968f5954bc37