### PR TITLE
Update styling for form labels and button

### DIFF
--- a/app.py
+++ b/app.py
@@ -33,6 +33,18 @@ st.markdown(
         div[data-testid="stDownloadButton"] button {
             color: #000000;
         }
+        /* Make form field labels white */
+        label {
+            color: #ffffff !important;
+        }
+        /* Style the primary action button */
+        div.stButton > button {
+            background-color: #000000;
+            color: #ffffff;
+        }
+        div.stButton > button:hover {
+            background-color: #333333;
+        }
     </style>
     """,
     unsafe_allow_html=True,

--- a/app_contextual.py
+++ b/app_contextual.py
@@ -31,6 +31,18 @@ st.markdown(
         div[data-testid="stDownloadButton"] button {
             color: #000000;
         }
+        /* Make form field labels white */
+        label {
+            color: #ffffff !important;
+        }
+        /* Style the primary action button */
+        div.stButton > button {
+            background-color: #000000;
+            color: #ffffff;
+        }
+        div.stButton > button:hover {
+            background-color: #333333;
+        }
     </style>
     """,
     unsafe_allow_html=True,


### PR DESCRIPTION
## Summary
- update CSS in Streamlit apps
  - make text input labels white
  - show Scan Titles button with black background

## Testing
- `python -m py_compile app.py app_contextual.py scan_titles_weighted.py scan_titles_weighted_contextual_v3_riskaware.py context_flags.py`

------
https://chatgpt.com/codex/tasks/task_e_6862e0fa7ea08331b01afda2bbc64ec6