### PR TITLE
Add HTML wave section demo

### DIFF
--- a/wave-section.html
+++ b/wave-section.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Wave Section Demo</title>
+<style>
+  :root {
+    --primary-red:   #FF0230;
+    --secondary-red: #951E3D;
+    --mint:          #62A362;
+    --black:         #020000;
+    --light-black:   #2E2E2E;
+    --gray:          #F3F1F4;
+    --white:         #FFFFFF;
+  }
+  body {
+    margin: 0;
+    font-family: Arial, sans-serif;
+    background: var(--gray);
+  }
+  .wave-section {
+    position: relative;
+    width: 100%;
+    color: var(--white);
+    padding: 4rem 1rem 6rem; /* extra bottom padding for wave overlap */
+    background: linear-gradient(135deg, var(--primary-red), var(--mint));
+    overflow: hidden;
+  }
+  .wave-section h1 {
+    margin: 0;
+    font-size: 2rem;
+    text-align: center;
+  }
+  .wave-section svg {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 100px;
+  }
+</style>
+</head>
+<body>
+  <section class="wave-section">
+    <h1>Modern Wave Section</h1>
+    <svg viewBox="0 0 1440 100" preserveAspectRatio="none">
+      <path d="M0,30 C200,80 400,0 600,30 C800,60 1000,20 1200,40 C1300,50 1400,40 1440,30 L1440,100 L0,100 Z" fill="var(--gray)"></path>
+    </svg>
+  </section>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `wave-section.html` demonstrating a full-width wave background with diagonal red-to-mint gradient

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862e51922e4833194906c6d842ceb9a