### PR TITLE
Add branded header with scoped styles

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 
 import os
+import base64
 from dotenv import load_dotenv
 import streamlit as st
 import pandas as pd
@@ -14,21 +15,55 @@ load_dotenv()
 
 st.set_page_config(page_title="YouTube Title Scanner", layout="centered")
 
-# Optional subtitle styling scoped to a class so it doesn't affect other elements
-st.markdown(
-    """
-    <style>
-        .subtitle {
-            font-weight: 600;
-        }
-    </style>
-    """,
-    unsafe_allow_html=True,
-)
+with open("assets/Studio71_Icon_White.png", "rb") as img_file:
+    logo_b64 = base64.b64encode(img_file.read()).decode()
 
-st.title("YouTube Title Scanner")
 st.markdown(
-    "<p class='subtitle'>Scan a YouTube channel for advertiser-unfriendly words and suggest safer alternatives.</p>",
+    f"""
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;800&display=swap');
+        .branded-content {{
+            font-family: 'Montserrat', sans-serif;
+        }}
+        .wave-section {{
+            background: linear-gradient(135deg, #FF0230, #62A362);
+            color: #FFFFFF;
+            text-align: center;
+            position: relative;
+            padding: 3rem 1rem 6rem;
+            overflow: hidden;
+        }}
+        .wave-section .logo {{
+            width: 120px;
+            margin-bottom: 1rem;
+        }}
+        .wave-section h1 {{
+            font-weight: 800;
+            margin-bottom: 0.2rem;
+        }}
+        .wave-section .subtitle {{
+            font-weight: 300;
+            margin: 0;
+        }}
+        .wave-section svg {{
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            width: 100%;
+            height: 80px;
+        }}
+        .results-table {{
+        }}
+    </style>
+    <div class="branded-content wave-section">
+        <img src="data:image/png;base64,{logo_b64}" class="logo" alt="Studio71 logo" />
+        <h1>YouTube Title Scanner</h1>
+        <p class="subtitle">Scan a YouTube channel for advertiser-unfriendly words and suggest safer alternatives.</p>
+        <svg viewBox="0 0 1440 100" preserveAspectRatio="none">
+            <path d="M0,30 C200,80 400,0 600,30 C800,60 1000,20 1200,40 C1300,50 1400,40 1440,30 L1440,100 L0,100 Z" fill="#F3F1F4"></path>
+        </svg>
+    </div>
+    """,
     unsafe_allow_html=True,
 )
 
@@ -118,7 +153,9 @@ if st.button("Scan Titles") and api_key and channel_id:
                 )
 
                 st.success("Scan complete!")
+                st.markdown("<div class='results-table'>", unsafe_allow_html=True)
                 st.dataframe(styled_df, use_container_width=True)
+                st.markdown("</div>", unsafe_allow_html=True)
 
                 from io import BytesIO
                 from openpyxl.utils import get_column_letter

--- a/app_contextual.py
+++ b/app_contextual.py
@@ -1,5 +1,6 @@
 
 import os
+import base64
 from dotenv import load_dotenv
 import streamlit as st
 import pandas as pd
@@ -12,21 +13,55 @@ load_dotenv()
 
 st.set_page_config(page_title="YouTube Video Title Scanner", layout="centered")
 
-# Optional subtitle styling scoped to a class
-st.markdown(
-    """
-    <style>
-        .subtitle {
-            font-weight: 600;
-        }
-    </style>
-    """,
-    unsafe_allow_html=True,
-)
+with open("assets/Studio71_Icon_White.png", "rb") as img_file:
+    logo_b64 = base64.b64encode(img_file.read()).decode()
 
-st.title("YouTube Video Title Scanner")
 st.markdown(
-    "<p class='subtitle'>Scan a YouTube channel for advertiser-unfriendly words and suggest safer alternatives.</p>",
+    f"""
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;800&display=swap');
+        .branded-content {{
+            font-family: 'Montserrat', sans-serif;
+        }}
+        .wave-section {{
+            background: linear-gradient(135deg, #FF0230, #62A362);
+            color: #FFFFFF;
+            text-align: center;
+            position: relative;
+            padding: 3rem 1rem 6rem;
+            overflow: hidden;
+        }}
+        .wave-section .logo {{
+            width: 120px;
+            margin-bottom: 1rem;
+        }}
+        .wave-section h1 {{
+            font-weight: 800;
+            margin-bottom: 0.2rem;
+        }}
+        .wave-section .subtitle {{
+            font-weight: 300;
+            margin: 0;
+        }}
+        .wave-section svg {{
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            width: 100%;
+            height: 80px;
+        }}
+        .results-table {{
+        }}
+    </style>
+    <div class="branded-content wave-section">
+        <img src="data:image/png;base64,{logo_b64}" class="logo" alt="Studio71 logo" />
+        <h1>YouTube Video Title Scanner</h1>
+        <p class="subtitle">Scan a YouTube channel for advertiser-unfriendly words and suggest safer alternatives.</p>
+        <svg viewBox="0 0 1440 100" preserveAspectRatio="none">
+            <path d="M0,30 C200,80 400,0 600,30 C800,60 1000,20 1200,40 C1300,50 1400,40 1440,30 L1440,100 L0,100 Z" fill="#F3F1F4"></path>
+        </svg>
+    </div>
+    """,
     unsafe_allow_html=True,
 )
 
@@ -78,7 +113,9 @@ if st.button("Scan Titles") and api_key and channel_id:
                     cmap="RdYlGn", subset=["Safety Score"]
                 )
                 st.success("Scan complete!")
+                st.markdown("<div class='results-table'>", unsafe_allow_html=True)
                 st.dataframe(styled_df, use_container_width=True)
+                st.markdown("</div>", unsafe_allow_html=True)
 
                 # ✅ Excel download block
                 from io import BytesIO


### PR DESCRIPTION
## Summary
- add Montserrat fonts and load logo image
- create gradient wave header styled in `.wave-section`
- keep data table in unstyled `.results-table`

## Testing
- `python -m py_compile app.py app_contextual.py`

------
https://chatgpt.com/codex/tasks/task_e_6862ee99ef1c8331a00baddc54fb7a34