### PR TITLE
Fix CSS braces in Streamlit app

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,10 +22,10 @@ st.markdown(
     f"""
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;800&display=swap');
-        body {
+        body {{
             background-color: #0E1117;
             color: #FFFFFF;
-        }
+        }}
         .branded-content {{
             font-family: 'Montserrat', sans-serif;
         }}


### PR DESCRIPTION
## Summary
- escape CSS curly braces in `body {}` block

## Testing
- `python app.py`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6863015d57988331945381b5d7e4634d