### PR TITLE
Update banner gradient colors

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,6 +1,6 @@
 [theme]
 base="dark"
-primaryColor="#FF0230"
+primaryColor="#951E3D"
 backgroundColor="#0E1117"
 secondaryBackgroundColor="#262730"
 textColor="#FFFFFF"

--- a/app.py
+++ b/app.py
@@ -30,7 +30,7 @@ st.markdown(
             font-family: 'Montserrat', sans-serif;
         }}
         .wave-section {{
-            background: linear-gradient(135deg, #FF0230, #62A362);
+            background: linear-gradient(135deg, #951E3D, #00FFCF);
             color: #FFFFFF;
             text-align: center;
             position: relative;

--- a/app_contextual.py
+++ b/app_contextual.py
@@ -28,7 +28,7 @@ st.markdown(
             font-family: 'Montserrat', sans-serif;
         }}
         .wave-section {{
-            background: linear-gradient(135deg, #FF0230, #62A362);
+            background: linear-gradient(135deg, #951E3D, #00FFCF);
             color: #FFFFFF;
             text-align: center;
             position: relative;

--- a/wave-section.html
+++ b/wave-section.html
@@ -6,9 +6,9 @@
 <title>Wave Section Demo</title>
 <style>
   :root {
-    --primary-red:   #FF0230;
+    --primary-red:   #951E3D;
     --secondary-red: #951E3D;
-    --mint:          #62A362;
+    --mint:          #00FFCF;
     --black:         #020000;
     --light-black:   #2E2E2E;
     --gray:          #F3F1F4;


### PR DESCRIPTION
## Summary
- update gradient colors in banner to #951E3D and #00FFCF
- adjust HTML style variables to match
- update Streamlit theme primary color

## Testing
- `python -m py_compile app.py app_contextual.py scan_titles_weighted_contextual_v3_riskaware.py scan_titles_weighted.py context_flags.py`


------
https://chatgpt.com/codex/tasks/task_e_686429d5438483318bd40b3a32340f07